### PR TITLE
Arranca en primer plano

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ Uso: dinaIP [OPCIONES] ...
 - -l	Muestra una lista de los dominios pertenecientes a esta cuenta
 - -b	Elimina una zona de la monitorizacion. Sintaxis: dominio:zona_a_eliminar
 - -d	Detiene el demonio de dinaIP
+- -f	Arranca el demonio de DinaIP en primer plano y enva logs al terminal
 - -h	Despliega esta ayuda
 - -s	Muestra el status del demonio de dinaIP.

--- a/source/Debug.pm
+++ b/source/Debug.pm
@@ -6,25 +6,34 @@ use POSIX qw(strftime);
 my $INICIADO = undef;
 my $DEBUG = undef;
 
+my $PRIMERPLANO = undef;
+
 sub log{
 
-	&iniciar unless($INICIADO);
-	
-	my $fecha = strftime ("%Y-%m-%d %H:%M:%S",localtime());
-	print $DEBUG "[$fecha] $_[0] \n";	
+        &iniciar unless($INICIADO);
+
+        my $fecha = strftime ("%Y-%m-%d %H:%M:%S",localtime());
+        print $DEBUG "[$fecha] $_[0] \n";
 
 }
 
 sub iniciar{
+        if ($PRIMERPLANO == 1) {
+                open ($DEBUG, '>>', '/dev/stdin') ||
+                        die($!);
+        } else {
+                open ($DEBUG, '>>', '/var/log/dinaip.log') ||
+                        die($!);
+        }
 
-	open ($DEBUG, '>>', '/var/log/dinaip.log') ||
-		die($!);
+        $DEBUG->autoflush;
 
-	$DEBUG->autoflush;
+        $INICIADO = 1;
+}
 
-	$INICIADO = 1;
+sub setPrimerPlano{
+        $PRIMERPLANO = $_[0];
 }
 
 
 1;
-

--- a/source/Demonio.pm
+++ b/source/Demonio.pm
@@ -21,25 +21,26 @@ my $AVISO_RECARGA = undef;
 
 sub iniciar{
 
-	&Debug::log('Iniciando proceso...');
+        &Debug::log('Iniciando proceso...');
 
-	my $proceso = $_[0];
-	my $frecuencia = $_[1] || $FRECUENCIA;
-		
-	if(my $pid = &demonizar){
+        my $proceso = $_[0];
+        my $frecuencia = $_[1] || $FRECUENCIA;
+        my $primerPlano = $_[2] || 0;
 
-		open (F, '>', $RUTA_PID);
-		print F $pid;
-		close F; 
+        if(!$primerPlano && (my $pid = &demonizar)){
 
-		exit(0);
-	}
-	else{
+                open (F, '>', $RUTA_PID);
+                print F $pid;
+                close F;
 
-		&setDemonioCorriendo;
+                exit(0);
+        }
+        else{
 
-		&procesar;
-	}
+                &setDemonioCorriendo;
+
+                &procesar;
+        }
 }
 
 sub procesar{

--- a/source/dinaip.pl
+++ b/source/dinaip.pl
@@ -10,6 +10,7 @@ sub BEGIN {
 
 use strict;
 use Comando;
+use Debug;
 use Demonio;
 use ConfiguracionDinapiIp;
 use Proceso;
@@ -27,10 +28,14 @@ unless($> == 0){
 
 my %opciones;
 
-getopts('isdhla:b:u:p:', \%opciones);
+getopts('isfdhla:b:u:p:', \%opciones);
 
 unless(keys(%opciones)){
 	&ayuda();
+}
+
+if(exists($opciones{f})){
+        &Debug::setPrimerPlano(1);
 }
 
 # autentificamos primero si nos pasan usuario
@@ -91,7 +96,7 @@ sub iniciar{
 
 	&Demonio::iniciar(sub {
 		&Proceso::run(@_);
-	}, $configuracion->frecuencia);
+	}, $configuracion->frecuencia, exists($opciones{f}));
 }
 
 sub pedirCredenciales{
@@ -383,6 +388,7 @@ Uso: dinaip [OPCIONES] ...
 -l	Muestra una lista de los dominios pertenecientes a esta cuenta
 -b	Elimina una zona de la monitorización. Sintaxis: dominio:zona_a_eliminar
 -d	Detiene el demonio de DinaIP
+-f      Arranca el demonio de DinaIP en primer plano y enva logs al terminal
 -h	Despliega esta ayuda
 -s	Muestra el status del demonio de DinaIP. 
 


### PR DESCRIPTION
Este cambio permite que el servicio arranque en primer plano y se envíen los logs a stdout al iniciar el servicio con el parámetro -f (foreground).

La idea es facilitar la integración del servicio con contenedores.